### PR TITLE
Fixed compile error with internal class

### DIFF
--- a/sub_commands/histo_main.cc
+++ b/sub_commands/histo_main.cc
@@ -54,7 +54,7 @@ int histo_main(int argc, char *argv[])
   jellyfish::mer_dna::k(header.key_len() / 2);
 
   if(args.high_arg < args.low_arg)
-    args.error("High count value must be >= to low count value");
+    histo_main_cmdline::error("High count value must be >= to low count value");
   ofstream_default out(args.output_given ? args.output_arg : 0, std::cout);
   if(!out.good())
     die << "Error opening output file '" << args.output_arg << "'" << jellyfish::err::no;


### PR DESCRIPTION
Hi Guillaume,
This is Derek with Gabor Marth's group @ Boston College. We've integrated Jellyfish into our unified analysis pipeline/launcher project, GKNO (www.gkno.me , https://github.com/gkno/gkno_launcher ). Feel free to ping back with any questions, comments, concerns, suggestions, etc.

I came across a compile error on 2 of our machines (both using gcc 4.6.3). My fix is in this pull request. 

Thanks,
- Derek
