### PR TITLE
base for parallel merge

### DIFF
--- a/include/jellyfish/binary_dumper.hpp
+++ b/include/jellyfish/binary_dumper.hpp
@@ -94,24 +94,43 @@ class binary_reader {
   Val                           val_;
   const RectangularBinaryMatrix m_;
   const size_t                  size_mask_;
+  uint64_t                      min_pos_;
+  uint64_t                      max_pos_;
 
 public:
   binary_reader(std::istream& is, // stream containing data (past any header)
                 file_header* header) :  // header which contains counter_len, matrix, size and key_len
     is_(is), val_len_(header->counter_len()), key_(header->key_len() / 2),
     m_(header->matrix()),
-    size_mask_(header->size() - 1)
+    size_mask_(header->size() - 1),
+    min_pos_(0),
+    max_pos_(std::numeric_limits<uint64_t>::max())
   { }
 
   const Key& key() const { return key_; }
   const Val& val() const { return val_; }
   size_t pos() const { return m_.times(key_) & size_mask_; }
+  uint64_t   min_pos()                                      const { return min_pos_; }
+  uint64_t   max_pos()                                      const { return max_pos_; }
+  void       min_pos(uint64_t min_pos)                            { min_pos_ = min_pos; }
+  void       max_pos(uint64_t max_pos)                            { max_pos_ = max_pos; }
+  void       min_max_pos(uint64_t min_pos, uint64_t max_pos)      { min_pos_ = min_pos; max_pos_ = max_pos; }
 
   bool next() {
-    key_.template read<1>(is_);
-    val_ = 0;
-    is_.read((char*)&val_, val_len_);
-    return is_.good();
+    if (( pos() < min_pos_ ) && (is_.good())) {
+      while ( pos() < min_pos_ ) {
+        key_.template read<1>(is_);
+        val_ = 0;
+        is_.read((char*)&val_, val_len_);
+      }
+      return is_.good() && pos() <= max_pos_;
+    
+    } else {
+      key_.template read<1>(is_);
+      val_ = 0;
+      is_.read((char*)&val_, val_len_);
+      return is_.good() && pos() <= max_pos_;
+    }
   }
 };
 

--- a/include/jellyfish/text_dumper.hpp
+++ b/include/jellyfish/text_dumper.hpp
@@ -77,6 +77,11 @@ public:
   const Key& key() const { return key_; }
   const Val& val() const { return val_; }
   size_t pos() const { return m_.times(key()) & size_mask_; }
+  uint64_t   min_pos()                                      const { return 0; }
+  uint64_t   max_pos()                                      const { return 0; }
+  void       min_pos(uint64_t min_pos)                            { }
+  void       max_pos(uint64_t max_pos)                            { }
+  void       min_max_pos(uint64_t min_pos, uint64_t max_pos)      { }
 
   bool next() {
     is_ >> key_ >> val_;

--- a/jellyfish/merge_files.hpp
+++ b/jellyfish/merge_files.hpp
@@ -23,8 +23,15 @@
 
 define_error_class(MergeError);
 
+typedef std::vector<uint64_t> uint64_vec;
+
 /// Merge files. Throw a MergeError in case of error.
 void merge_files(std::vector<const char*> input_files, const char* out_file,
-                 jellyfish::file_header& h, uint64_t min, uint64_t max);
+                 jellyfish::file_header& h,
+                 uint64_t min, uint64_t max);
 
+void merge_files2(std::vector<const char*> input_files, const char* out_file,
+                 jellyfish::file_header& h,
+                 uint64_t min, uint64_t max,
+                 uint64_vec min_pos, uint64_vec max_pos);
 #endif /* __JELLYFISH_MERGE_FILES_HPP__ */


### PR DESCRIPTION
Follows a pull request with the necessary changes to allow for parallel merging of databases.

It still needs the definition of the hashed position in each file as start and end points.

by splitting the biggest file in N (threads), get the sequences of all the 1/Nth positions, for each other file, get the hash of each position in their respective scale and use it to initialize the binary_reader.

arriving in the end position would return false in binary_read.next() . probably each Nth should be a partial file but they could be concatenated or written in parallel to the same file.
