### PR TITLE
Added an interactive mode to the query subcommand

### DIFF
--- a/sub_commands/query_main_cmdline.yaggo
+++ b/sub_commands/query_main_cmdline.yaggo
@@ -7,6 +7,9 @@ option("s", "sequence") {
 option("o", "output") {
   description "Output file (stdout)"
   c_string; typestr "path" }
+option("i", "interactive") {
+  description "Interactive, queries from stdin"
+  flag; off }
 arg("file") {
   description "Jellyfish database"
   c_string; typestr "path" }


### PR DESCRIPTION
Bonjour Guillaume,

I've added an interactive mode to the query subcommand.  It is activated with the -i flag and kmers are read one per line from stdin, the output is flushed.  The rationale for this feature is for using jellyfish as part of a front-end that makes dynamic queries.  A jellyfish process is launched on a DB and, through a pipe, queries can be made without going through the overhead of relaunching jellyfish.
