### PR TITLE
[CR] Update ax_ext.m4

### DIFF
--- a/m4/m4-ax_ext.m4
+++ b/m4/m4-ax_ext.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#          http://www.gnu.org/software/autoconf-archive/ax_ext.html
+#          https://www.gnu.org/software/autoconf-archive/ax_ext.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -44,7 +44,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 15
+#serial 17
 
 AC_DEFUN([AX_EXT],
 [

--- a/m4/m4-ax_ext.m4
+++ b/m4/m4-ax_ext.m4
@@ -31,12 +31,13 @@
 #     HAVE_SHA / HAVE_AES / HAVE_AVX / HAVE_FMA3 / HAVE_FMA4 / HAVE_XOP
 #     HAVE_AVX2 / HAVE_AVX512_F / HAVE_AVX512_CD / HAVE_AVX512_PF
 #     HAVE_AVX512_ER / HAVE_AVX512_VL / HAVE_AVX512_BW / HAVE_AVX512_DQ
-#     HAVE_AVX512_IFMA / HAVE_AVX512_VBMI
+#     HAVE_AVX512_IFMA / HAVE_AVX512_VBMI / HAVE_ALTIVEC / HAVE_VSX
 #
 # LICENSE
 #
 #   Copyright (c) 2007 Christophe Tournayre <turn3r@users.sourceforge.net>
 #   Copyright (c) 2013,2015 Michael Petch <mpetch@capp-sysware.com>
+#   Copyright (c) 2017 Rafael de Lucena Valle <rafaeldelucena@gmail.com>
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
@@ -55,18 +56,42 @@ AC_DEFUN([AX_EXT],
 
   case $host_cpu in
     powerpc*)
-      AC_CACHE_CHECK([whether altivec is supported], [ax_cv_have_altivec_ext],
+      AC_CACHE_CHECK([whether altivec is supported for old distros], [ax_cv_have_altivec_old_ext],
           [
             if test `/usr/sbin/sysctl -a 2>/dev/null| grep -c hw.optional.altivec` != 0; then
                 if test `/usr/sbin/sysctl -n hw.optional.altivec` = 1; then
-                  ax_cv_have_altivec_ext=yes
+                  ax_cv_have_altivec_old_ext=yes
                 fi
+            fi
+          ])
+
+          if test "$ax_cv_have_altivec_old_ext" = yes; then
+            AC_DEFINE(HAVE_ALTIVEC,,[Support Altivec instructions])
+            AX_CHECK_COMPILE_FLAG(-faltivec, SIMD_FLAGS="$SIMD_FLAGS -faltivec", [])
+          fi
+
+      AC_CACHE_CHECK([whether altivec is supported], [ax_cv_have_altivec_ext],
+          [
+            if test `LD_SHOW_AUXV=1 /bin/true 2>/dev/null|grep -c altivec` != 0; then
+              ax_cv_have_altivec_ext=yes
             fi
           ])
 
           if test "$ax_cv_have_altivec_ext" = yes; then
             AC_DEFINE(HAVE_ALTIVEC,,[Support Altivec instructions])
-            AX_CHECK_COMPILE_FLAG(-faltivec, SIMD_FLAGS="$SIMD_FLAGS -faltivec", [])
+            AX_CHECK_COMPILE_FLAG(-maltivec, SIMD_FLAGS="$SIMD_FLAGS -maltivec", [])
+          fi
+
+      AC_CACHE_CHECK([whether vsx is supported], [ax_cv_have_vsx_ext],
+          [
+            if test `LD_SHOW_AUXV=1 /bin/true 2>/dev/null|grep -c vsx` != 0; then
+                ax_cv_have_vsx_ext=yes
+            fi
+          ])
+
+          if test "$ax_cv_have_vsx_ext" = yes; then
+            AC_DEFINE(HAVE_VSX,,[Support VSX instructions])
+            AX_CHECK_COMPILE_FLAG(-mvsx, SIMD_FLAGS="$SIMD_FLAGS -mvsx", [])
           fi
     ;;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Added autoconf parameter to enable SSE instructions only on machines which have support for them, making disabled as default.

<!--- ## How Has This Been Tested? -->

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

<!--- ## Types of changes -->

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<!--- - [ ] Bug fix (non-breaking change which fixes an issue) -->

<!--- - [ ] New feature (non-breaking change which adds functionality) -->

<!--- - [ ] Breaking change (fix or feature that would cause existing functionality to change) -->
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Infer SSE
- [x] Define preprocessor HAVE_SSE flag
- [x] [Build JellyFish](https://gist.github.com/rafaeldelucena/81f9b0befd2c0b24eb2c8c7fcef43f8b) using ./configure with auto detection (without args) on ppc64le machine
<!--- - [ ] New feature (non-breaking change which adds functionality) -->

<!--- - [ ] Breaking change (fix or feature that would cause existing functionality to change) -->