### PR TITLE
Fix build with GCC8

### DIFF
--- a/include/jellyfish/hash_counter.hpp
+++ b/include/jellyfish/hash_counter.hpp
@@ -213,7 +213,7 @@ protected:
           new_ary_ = new  array(ary_->size(), ary_->key_len(), ary_->val_len() + 1,
                                 ary_->max_reprobe(), ary_->reprobes());
         }
-      } catch(typename array::ErrorAllocation e) {
+      } catch(typename array::ErrorAllocation &e) {
         new_ary_ = 0;
       }
     }

--- a/sub_commands/count_main.cc
+++ b/sub_commands/count_main.cc
@@ -360,7 +360,7 @@ int count_main(int argc, char *argv[])
         uint64_t max = args.upper_count_given ? args.upper_count_arg : std::numeric_limits<uint64_t>::max();
         try {
           merge_files(files, args.output_arg, header, min, max);
-        } catch(MergeError e) {
+        } catch(MergeError &e) {
           err::die(err::msg() << e.what());
         }
         if(!args.no_unlink_flag) {

--- a/sub_commands/merge_main.cc
+++ b/sub_commands/merge_main.cc
@@ -33,7 +33,7 @@ int merge_main(int argc, char *argv[])
 
   try {
     merge_files(args.input_arg, args.output_arg, out_header, min, max);
-  } catch(MergeError e) {
+  } catch(MergeError &e) {
     err::die(err::msg() << e.what());
   }
 

--- a/sub_commands/query_main.cc
+++ b/sub_commands/query_main.cc
@@ -60,7 +60,7 @@ void query_from_cmdline(std::vector<const char*> mers, const Database& db, std::
       if(canonical)
         m.canonicalize();
       out << m << " " << db.check(m) << "\n";
-    } catch(std::length_error e) {
+    } catch(std::length_error &e) {
       std::cerr << "Invalid mer '" << *it << "'\n";
     }
   }
@@ -77,7 +77,7 @@ void query_from_stdin(const Database& db, std::ostream& out, bool canonical) {
       if(canonical)
         m.canonicalize();
       out << db.check(m) << std::endl;  // a flush is need for interactive use
-    } catch(std::length_error e) {
+    } catch(std::length_error &e) {
       std::cerr << "Invalid mer '" << buffer << "'" << std::endl;
     }
   }


### PR DESCRIPTION
Replace couple of exceptions from using value to references:
```
sub_commands/count_main.cc:333:28: error: catching polymorphic type 'class MergeError' by value [-Werror=catch-value=]
         } catch(MergeError e) {
```