### PR TITLE
Do not replace random '-L' strings in command line

### DIFF
--- a/examples/count_in_file/Makefile
+++ b/examples/count_in_file/Makefile
@@ -1,6 +1,6 @@
 CC = g++
 CXXFLAGS = $(shell pkg-config --cflags jellyfish-2.0) -std=c++0x -Wall -O3
-LDFLAGS = -Wl,--rpath=$(shell pkg-config --libs-only-L jellyfish-2.0 | sed -e 's/-L//g')
+LDFLAGS = -Wl,--rpath=$(shell pkg-config --libs-only-L jellyfish-2.0 | sed -e 's/ -L/ /g')
 LDLIBS = $(shell pkg-config --libs jellyfish-2.0)
 
 all: count_in_file

--- a/examples/jf_count_dump/Makefile
+++ b/examples/jf_count_dump/Makefile
@@ -1,6 +1,6 @@
 CC = g++
 CXXFLAGS = $(shell pkg-config --cflags jellyfish-2.0) -std=c++0x -Wall -O3
-LDFLAGS = -Wl,--rpath=$(shell pkg-config --libs-only-L jellyfish-2.0 | sed -e 's/-L//g')
+LDFLAGS = -Wl,--rpath=$(shell pkg-config --libs-only-L jellyfish-2.0 | sed -e 's/ -L/ /g')
 LDLIBS = $(shell pkg-config --libs jellyfish-2.0)
 
 all: jf_count_dump

--- a/examples/query_per_sequence/Makefile
+++ b/examples/query_per_sequence/Makefile
@@ -1,6 +1,6 @@
 CC = g++
 CXXFLAGS = $(shell pkg-config --cflags jellyfish-2.0) -std=c++0x -Wall -O3
-LDFLAGS = -Wl,--rpath=$(shell pkg-config --libs-only-L jellyfish-2.0 | sed -e 's/-L//g')
+LDFLAGS = -Wl,--rpath=$(shell pkg-config --libs-only-L jellyfish-2.0 | sed -e 's/ -L/ /g')
 LDLIBS = $(shell pkg-config --libs jellyfish-2.0)
 
 all: query_per_sequence

--- a/swig/Tuprules.tup
+++ b/swig/Tuprules.tup
@@ -86,7 +86,7 @@ endif
 ifdef JELLYFISH_RPATH
   JELLYFISH_RPATH = @(JELLYFISH_RPATH)
 else
-  JELLYFISH_RPATH = `pkg-config --libs-only-L jellyfish-2.0 | sed -e 's/-L/-Wl,-rpath,/g'`
+  JELLYFISH_RPATH = `pkg-config --libs-only-L jellyfish-2.0 | sed -e 's/ -L/ -Wl,-rpath,/g'`
 endif
 
 ifdef RUBY_CFLAGS

--- a/swig/perl5/Makefile.PL
+++ b/swig/perl5/Makefile.PL
@@ -19,7 +19,7 @@ my $pkg = "jellyfish-2.0";
 my $jf_cflags = pkgconfig("--cflags $pkg");
 my $jf_libs   = pkgconfig("--libs $pkg");
 my $jf_rpath  = pkgconfig("--libs-only-L $pkg");
-$jf_rpath =~ s/-L/-Wl,-rpath,/g;
+$jf_rpath =~ s/ -L/ -Wl,-rpath,/g;
 
 print("$jf_cflags\n$jf_libs\n$jf_rpath\n");
 

--- a/swig/python/setup.py
+++ b/swig/python/setup.py
@@ -23,7 +23,7 @@ def pkgconfig(s):
 jf_libs    = [re.sub(r'-l', '', x) for x in pkgconfig("--libs-only-l jellyfish-2.0")]
 jf_include = [re.sub(r'-I', '', x) for x in pkgconfig("--cflags-only-I jellyfish-2.0")]
 jf_cflags  = pkgconfig("--cflags-only-other jellyfish-2.0")
-jf_libdir  = [re.sub(r'-L', '', x) for x in pkgconfig("--libs-only-L jellyfish-2.0")]
+jf_libdir  = [re.sub(r' -L', ' ', x) for x in pkgconfig("--libs-only-L jellyfish-2.0")]
 jf_rpath   = [re.sub(r'^', '-Wl,-rpath,', x) for x in jf_libdir]
 jf_ldflags = pkgconfig("--libs-only-other jellyfish-2.0")
 

--- a/swig/ruby/extconf.rb
+++ b/swig/ruby/extconf.rb
@@ -19,7 +19,7 @@ end
 
 $defs << pkgconfig("--cflags jellyfish-2.0") << '-std=c++0x'
 libs = [pkgconfig("--libs jellyfish-2.0"),
-        pkgconfig("--libs-only-L jellyfish-2.0").gsub(/-L/, "-Wl,-rpath,")]
+        pkgconfig("--libs-only-L jellyfish-2.0").gsub(/ -L/, " -Wl,-rpath,")]
 
 if Array === $libs
   $libs += libs


### PR DESCRIPTION
Hello,

This is a patch we've applied to the Debian packaging of Jellyfish since 2018-09-03 and I thought I'd see if you all would merge it here.

Source: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=907819

Thanks!