### PR TITLE
small_mers needs bash

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,4 @@
+SHELL = /bin/bash
 ACLOCAL_AMFLAGS = -I m4
 
 EXTRA_DIST = doc/jellyfish.pdf doc/jellyfish.man README LICENSE # jellyfish.spec

--- a/tests/small_mers.sh
+++ b/tests/small_mers.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 cd tests
 . ../compat.sh


### PR DESCRIPTION
Due to process substitution.

Thanks to https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/jellyfish.html for highlighting this.