### PR TITLE
configure.ac: protect some md5 macros with []

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,9 +41,9 @@ AS_IF([test "x$UNIX2DOS" = "x"],
 
 # Check for md5 or md5sum
 AC_ARG_VAR([MD5], [Path to md5 hashing program])
-AS_IF([test "x$MD5" = "x"], AC_CHECK_PROG([MD5], [md5sum], [md5sum]), [])
-AS_IF([test "x$MD5" = "x"], AC_CHECK_PROG([MD5], [md5], [md5 -r]), [])
-AS_IF([test "x$MD5" = "x"], AC_MSG_ERROR([Could not find md5 hashing program in your path]), [])
+AS_IF([test "x$MD5" = "x"], [AC_CHECK_PROG([MD5], [md5sum], [md5sum])], [])
+AS_IF([test "x$MD5" = "x"], [AC_CHECK_PROG([MD5], [md5], [md5 -r])], [])
+AS_IF([test "x$MD5" = "x"], [AC_MSG_ERROR([Could not find md5 hashing program in your path])], [])
 
 # Check for yaggo
 AC_ARG_VAR([YAGGO], [Yaggo switch parser generator])


### PR DESCRIPTION
Greetings,

Starting with autoconf 2.70, the resulting _./configure_ script seems to not be valid shell anymore, leading to Debian bug #978843 [1].

[1]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=978843

Relevant part from the complete build log:

```
[...]
checking for samtools... /usr/bin/samtools
checking for unix2dos... /usr/bin/unix2dos
./configure: line 13206: syntax error near unexpected token `newline'
./configure: line 13206: `    '''
[...]
```

Putting square brackets to protect MD5 sum related macros seems to solve the issue.

In hope this helps,
Have a nice day,  :)
Étienne.