### PR TITLE
Enable build on 32bit architectures

### DIFF
--- a/include/jellyfish/mer_dna.hpp
+++ b/include/jellyfish/mer_dna.hpp
@@ -693,7 +693,7 @@ inline std::istream& operator>>(std::istream& is, mer_base<derived>& mer) {
 
   char buffer[mer.k() + 1];
   is.read(buffer, mer.k());
-  if(is.gcount() != mer.k())
+  if(static_cast<unsigned int>(is.gcount()) != mer.k())
     goto error;
   buffer[mer.k()] = '\0';
   if(!mer.from_chars(buffer))

--- a/include/jellyfish/rectangular_binary_matrix.hpp
+++ b/include/jellyfish/rectangular_binary_matrix.hpp
@@ -118,7 +118,7 @@ namespace jellyfish {
       uint64_t *p = _columns;
       while(*p == 0 && p < _columns + _c)
         ++p;
-      return (p - _columns) == _c;
+      return static_cast<unsigned int>(p - _columns) == _c;
     }
 
     // Randomize the content of the matrix

--- a/unit_tests/test_mer_dna.cc
+++ b/unit_tests/test_mer_dna.cc
@@ -466,7 +466,7 @@ TYPED_TEST(MerDNA, GetBits) {
 
     // Get bits by right-shifting
     typename TypeParam::Type cm(m);
-    for(unsigned int j = 1; j < start; j += 2)
+    for(unsigned long int j = 1; start>=0 && j < static_cast<unsigned int>(start); j += 2)
       cm.shift_right(0); // Shift by 2 bits
     typename TypeParam::Type::base_type y = cm.word(0);
     if(start & 0x1)


### PR DESCRIPTION
We've been carrying this patch in Debian since 2020. Optionally we can stop building for 32-bit architectures, which I find reasonable for bioinformatic software.